### PR TITLE
Neo4j >= 4 compatibility (shortestonly and dijkstra-cypher algorithms only)

### DIFF
--- a/aclpwn/__init__.py
+++ b/aclpwn/__init__.py
@@ -103,7 +103,7 @@ def main():
                 paths = pathfinding.dijkstra_find_cypher(from_object, to_object, args.from_type.capitalize(), args.to_type.capitalize())
             else:
                 # First we need to obtain the node IDs for use with the REST api
-                q = "MATCH (n:%s {name: {name}}) RETURN n"
+                q = "MATCH (n:%s {name: $name}) RETURN n"
                 with database.driver.session() as session:
                     fromres = session.run(q % args.from_type.capitalize(), name=from_object)
                     try:

--- a/aclpwn/database.py
+++ b/aclpwn/database.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals, print_function
-from neo4j.v1 import GraphDatabase
+from neo4j import GraphDatabase
 import platform
 import requests
 import json

--- a/aclpwn/pathfinding.py
+++ b/aclpwn/pathfinding.py
@@ -30,6 +30,7 @@ def dijkstra_find(fromid, toid, dbhost):
       "cost_property": "aclpwncost",
       "default_cost": 1
     }
+    print(fromid)
     resp = database.restapi.post('http://%s:7474/db/data/node/%s/paths' % (dbhost, fromid), json=data)
     data = resp.json()
     paths = []
@@ -52,8 +53,9 @@ def dijkstra_find_cypher(startnode, endnode, starttype='User', endtype='User'):
             for record in tx.run(query % (starttype, endtype), startnode=startnode, endnode=endnode, property='aclpwncost'):
                 path.append(record)
     paths = []
-    nodes, rels = resolve_dijkstra_path(path[0])
-    paths.append((nodes, rels, path[0]))
+    if path:
+        nodes, rels = resolve_dijkstra_path(path[0])
+        paths.append((nodes, rels, path[0]))
     return paths
 
 

--- a/aclpwn/pathfinding.py
+++ b/aclpwn/pathfinding.py
@@ -30,7 +30,6 @@ def dijkstra_find(fromid, toid, dbhost):
       "cost_property": "aclpwncost",
       "default_cost": 1
     }
-    print(fromid)
     resp = database.restapi.post('http://%s:7474/db/data/node/%s/paths' % (dbhost, fromid), json=data)
     data = resp.json()
     paths = []

--- a/aclpwn/utils.py
+++ b/aclpwn/utils.py
@@ -11,7 +11,7 @@ def print_path(record):
     # Iterate the path
     pathtext = '(%s)-' % record['p'].nodes[0].get('name')
     for el in record['p']:
-        pathtext += '[%s]->(%s)-' % (el.type, nmap[el.end].get('name'))
+        pathtext += '[%s]->(%s)-' % (el.type, nmap[el.end_node.id].get('name'))
     pathtext = pathtext[:-1]
     return pathtext
 
@@ -20,7 +20,7 @@ def build_path(record):
     nmap = getnodemap(record['p'].nodes)
     # Iterate the path
     for el in record['p']:
-        path.append((el, nmap[el.end]))
+        path.append((el, nmap[el.end_node.id]))
     return path
 
 def build_rest_path(nodes, rels):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 neo4j-driver
 impacket
 ldap3
+requests


### PR DESCRIPTION
Hi,

This should allow to use aclpwn.py with **neo4j >= 4.0** and **python >= 3** with algorithms **shortestonly** and **dijkstra-cypher**.

- shortestonly and dijkstra-cypher were broken because of syntax changes since neo4j v4.
- dijkstra-cypher was partly broken because Graph Algorithms Library was [deprecated](https://neo4j.com/docs/graph-algorithms/current/labs-algorithms/shortest-path/) by GDS.
- Default algorithm (dijkstra) **STILL** need to be re-implemented since REST API was [removed](https://neo4j.com/docs/rest-docs/current/) from neo4j v4.

This needs to be double checked. However, it should fix #4 and fix #6. Hope it helps.